### PR TITLE
[Week3] 추지온: 네트워크, 입국심사, 메뉴 리뉴얼, 후보키

### DIFF
--- a/src/jionchu/Week3/네트워크.kt
+++ b/src/jionchu/Week3/네트워크.kt
@@ -1,0 +1,34 @@
+/* Programmers
+ * 깊이/너비 우선 탐색(DFS/BFS) - 네트워크
+ * created on 2021.10.10
+ * created by jionchu */
+
+class Solution {
+    val disconnected = mutableListOf<Int>()
+    
+    fun solution(n: Int, computers: Array<IntArray>): Int {
+        var answer = 0
+        for (i in 0 until n) disconnected.add(i)
+        
+        while (disconnected.size > 0) {
+            // 새로운 네트워크
+            answer++
+            
+            dfs(n, computers, disconnected.removeAt(0))
+        }
+        
+        return answer
+    }
+    
+    fun dfs(n: Int, computers: Array<IntArray>, computer: Int) {
+        for (i in 0 until n) {
+            // 두 컴퓨터가 연결되어 있는 경우
+            if (disconnected.contains(i) && computers[computer][i] == 1) {
+                // 네트워크에 속하게 되는 컴퓨터는 리스트에서 제거
+                disconnected.remove(i)
+                
+                dfs(n, computers, i)
+            }
+        }
+    }
+}

--- a/src/jionchu/Week3/메뉴 리뉴얼.kt
+++ b/src/jionchu/Week3/메뉴 리뉴얼.kt
@@ -1,0 +1,57 @@
+/* Programmers
+ * 2021 KAKAO BLIND RECRUITMENT - 메뉴 리뉴얼
+ * created on 2021.10.10
+ * created by jionchu */
+
+class Solution {
+    lateinit var map: MutableMap<String, Int>
+    
+    fun solution(orders: Array<String>, course: IntArray): Array<String> {
+        var answer = mutableListOf<String>()
+        
+        for (n in course) {
+            map = mutableMapOf()
+            
+            // n개로 구성할 수 있는 코스요리 조합
+            for (order in orders) {
+                // 알파벳 오름차순 정렬
+                dfs(order.toCharArray().sorted().joinToString(""), n, 0, "")
+            }
+            
+            // 개수 순 정렬
+            val menuList = map.toList().sortedByDescending { it.second }
+            
+            // 가장 개수가 많은 코스요리 추가
+            if (menuList.size == 0) continue
+                
+            var max = menuList[0].second
+            for (i in menuList.indices) {
+                if (menuList[i].second == max && menuList[i].second > 1)
+                    answer.add(menuList[i].first)
+                else break
+            }
+        }
+        
+        // 오름차순 정렬
+        answer.sort()
+        return answer.toTypedArray()
+    }
+    
+    // 가능한 모든 코스요리 조합 만들기
+    fun dfs(order: String, more: Int, current: Int, menu: String) {
+
+        if (more == 0) {
+            val total = map.getOrDefault(menu, 0) + 1
+            map.put(menu, total)
+            
+            return
+        }
+        
+        if (order.length == current) {
+            return
+        }
+        
+        dfs(order, more-1, current+1, menu+order[current])
+        dfs(order, more, current+1, menu)
+    }
+}

--- a/src/jionchu/Week3/입국심사.kt
+++ b/src/jionchu/Week3/입국심사.kt
@@ -1,0 +1,29 @@
+/* Programmers
+ * 이분탐색 - 입국심사
+ * created on 2021.10.05
+ * created by jionchu */
+
+class Solution {
+    fun solution(n: Int, times: IntArray): Long {
+        var min: Long = n.toLong()/times.size*times.min()!!.toLong()
+        var max: Long = times.max()!!.toLong() * n
+        
+        while (min <= max) {
+            val mid = (min+max)/2
+            
+            // 현재 시간 안에 n명의 사람을 모두 심사할 수 있는지
+            var sum: Long = 0
+            times.forEach { sum += mid/it }
+            
+            // 모두 심사 가능한 경우
+            // 더 짧은 시간으로 가능한지 확인
+            if (sum >= n) max = mid-1
+            
+            // 모두 심사 가능하지 않은 경우
+            // 더 많은 시간 필요
+            else min = mid + 1
+        }
+        
+        return max + 1
+    }
+}

--- a/src/jionchu/Week3/후보키.kt
+++ b/src/jionchu/Week3/후보키.kt
@@ -1,0 +1,64 @@
+/* Programmers
+ * 2019 KAKAO BLIND RECRUITMENT - 후보키
+ * created on 2021.10.10
+ * created by jionchu */
+
+class Solution {
+    val keyMap: MutableMap<String, MutableSet<String>> = mutableMapOf()
+    
+    fun solution(relation: Array<Array<String>>): Int {
+        
+        // key로 만들 수 있는 튜플들 저장
+        repeat(relation.size) { comb(relation, it, 0, "", "") }
+        
+        // 유일성을 만족시키는 후보키들
+        val candidates = keyMap.filter { it.value.size == relation.size }.toSortedMap(compareBy<String> { it.length }.thenBy { it })
+        
+        val answer = mutableListOf<String>()
+        
+        // 각 후보키가 최소성을 만족하는지 확인
+        for (key in candidates.keys) {
+            val keyCount = key.length
+            
+            answer.add(key)
+            
+            for (candidate in answer) {
+                if (candidate.length >= keyCount) break
+                else if (!isMinimal(key, candidate)) {
+                    // 최소성을 만족하지 않는 경우 삭제
+                    answer.remove(key)
+                    break
+                }
+            }
+        }
+        
+        return answer.size
+    }
+    
+    // 후보키 조합 함수
+    fun comb(relation: Array<Array<String>>, n: Int, key: Int, keySet: String, tuple: String) {
+        
+        if (key == relation[0].size && tuple.isNotEmpty()) {
+            val tuples = keyMap.getOrDefault(keySet, mutableSetOf())
+            tuples.add(tuple)
+            keyMap.put(keySet, tuples)
+        }
+        
+        if (relation[0].size == key) return
+        
+        comb(relation, n, key+1, keySet+key, tuple+relation[n][key])
+        comb(relation, n, key+1, keySet, tuple)
+    }
+    
+    // 최소성 검사 함수
+    fun isMinimal(key: String, candidate: String): Boolean {
+        var count = 0
+        
+        // candidate의 모든 key들이 key에 포함되는지 확인
+        for (c in candidate) {
+            if (key.contains(c)) count++
+        }
+        
+        return count != candidate.length
+    }
+}


### PR DESCRIPTION
### 📒 Issue Number
linked issue #12

---

### 📢 풀이 알고리즘
```
네트워크: dfs
입국심사: 이분탐색
메뉴 리뉴얼: 조합, map, 정렬
후보키: 조합, map, set
```

---

### 💎 문제 해결
```
네트워크: ⭕
입국심사: ⭕️
메뉴 리뉴얼: ⭕
후보키: ⭕
```

---

### 🔥 특이사항/질문
[네트워크]
- 모든 컴퓨터들을 disconnected 배열에 넣어 초기화합니다.
- disconnected 배열에 있는 컴퓨터가 없을 때까지 dfs로 연결된 모든 컴퓨터들을 확인한 후 disconnected 배열에서 제거합니다.
---

[입국심사]
- 모든 사람들을 심사하는데 걸리는 최소, 최대 시간을 계산한다.
- 최소, 최대 시간을 기준으로 이분탐색하며 각 심사관들이 심사할 수 있는 인원 수를 구한다.
- 위에서 구한 인원수가 n보다 큰 경우 더 짧은 시간 안에 심사가 가능한지 확인하고, 인원수가 n보다 작은 경우 더 많은 시간으로 심사가 가능한지 확인한다.

---
[메뉴 리뉴얼]
- map을 이용해 dfs를 진행하면서 order 중 n개로 만들 수 있는 코스메뉴와 그 개수를 저장한다.
- 이 때 order의 알파벳들을 오름차순 정렬한 후 코스메뉴를 만들어야 개수를 제대로 셀 수 있습니다.
- 코스메뉴들의 개수를 비교해 2명 이상 주문한 메뉴 중 가장 많이 주문한 메뉴들을 저장합니다.
- 저장된 코스메뉴들을 알파벳 순으로 오름차순 정렬합니다.

---
[후보키]
- 존재하는 key들로 만들 수 있는 모든 키조합과 튜플들을 저장합니다.
- 그 중 유일성을 만족하는 키들을 구합니다.
- 각 키가 최소성을 만족하는지 검사해 최소성을 만족하는 경우만 정답 배열에 존재하도록 합니다.
